### PR TITLE
btsnoop: hci: return dataclasses instead of tuples

### DIFF
--- a/btsnoop/bt/hci_acl.py
+++ b/btsnoop/bt/hci_acl.py
@@ -1,6 +1,7 @@
 """
 Parse HCI ACL packets
 """
+import dataclasses
 import struct
 import ctypes
 from ctypes import c_uint
@@ -52,12 +53,25 @@ PB_FLAGS = {
         PB_COMPLETE_L2CAP_PDU : "ACL_PB COMPLETE_L2CAP_PDU"
     }
 
+
+@dataclasses.dataclass
+class HciPacketACL:
+    handle: int
+    pb: int
+    bc: int
+    length: int
+    data: bytearray
+
+    def __repr__(self):
+        return f"HciPacketACL(handle={self.handle}, pb={self.pb} ({pb_to_str(self.pb)}, bc={self.bc}, length={self.length}, data={self.data})"
+
 def pb_to_str(pb):
     """
     Return a string representing the packet boundary flag
     """
     assert pb in [0, 1, 2, 3]
     return PB_FLAGS[pb]
+
 
 
 def parse(data):
@@ -77,4 +91,4 @@ def parse(data):
     bc = int(hdr.b.bc)
     length = int(hdr.b.length)
     # print(f'ACL::{struct.unpack("<BB", data[:2])}', handle, pb, bc, length)
-    return (handle, pb, bc, length, data[4:])
+    return HciPacketACL(handle, pb, bc, length, data[4:])

--- a/btsnoop/bt/hci_cmd.py
+++ b/btsnoop/bt/hci_cmd.py
@@ -504,4 +504,4 @@ def parse(data):
     Returns a tuple of (opcode, length, data)
     """
     opcode, length = struct.unpack("<HB", data[:3])
-    return opcode, length, data[3:]
+    return parse_cmd_data(opcode, data[3:])

--- a/btsnoop/bt/hci_evt.py
+++ b/btsnoop/bt/hci_evt.py
@@ -385,8 +385,8 @@ def parse(data):
     # print(f'EVT::{struct.unpack("<H", data[:2])}', evtcode, length)
 
     if evtcode != HCI_LE_META_EVENT: ## Non-LE
-        return (evtcode, length, None, data[2:])
+        return parse_evt_data(evtcode, None, data[2:])
     else: ## LE
         subevtcode = struct.unpack("<B", data[2:3])[0]
         # length -= 1 # Subtract length of SubEvent code # TODO: while this makes sense, does the protocol do it like this? or is the length inclusive of everything (even the subevt code?)
-        return (evtcode, length, subevtcode, data[3:])
+        return parse_evt_data(evtcode, subevtcode, data[3:])


### PR DESCRIPTION
Just saner for end users to work with.  In some cases, the data classes already existed, so just save the user that indirection.

Signed-off-by: Karl Palsson <karlp@etactica.com>